### PR TITLE
Swapaxes fix

### DIFF
--- a/datasets/README
+++ b/datasets/README
@@ -1,0 +1,14 @@
+Data downloaded from here:
+http://www.iam.unibe.ch/fki/databases/iam-on-line-handwriting-database/download-the-iam-on-line-handwriting-database
+Need to register in order to download "ascii-all.tar.gz",
+"lineStrokes-all.tar.gz", "trainset.txt", "testset_t.txt", "testset_f.txt",
+and "testset_v.txt". Once done, the tar.gz files should be unzipped, revealing
+directory structures "ascii" and "lineStrokes".
+
+The ultimate train/valid splits for this dataset are taken from
+"Generating Sequences With Recurrent Neural Networks", Alex Graves, 2013.
+See section 4: Handwriting Prediction for a detailed breakdown. The directions
+according to the paper indicate combining "trainset.txt", "testset_t.txt", and
+"testset_f.txt" into one trianing set, while using "testset_v.txt" as valid.
+
+This is reflected in the files "train.txt" and "valid.txt".

--- a/datasets/iamondb.py
+++ b/datasets/iamondb.py
@@ -94,9 +94,17 @@ class IAMOnDB(TemporalSeries, SequentialPrepMixin):
 
         batches = [mat[start:end] for mat in self.data]
         label_batches = [mat[start:end] for mat in self.labels]
-        mask = self.create_mask(batches[0].swapaxes(0, 1))
+        len_batches = len(batches[0].shape)
+        if(len_batches <= 1):
+            mask = self.create_mask(batches[0])
+        else:
+            mask = self.create_mask(batches[0].swapaxes(0, 1))
         batches = [self.zero_pad(batch) for batch in batches]
-        label_mask = self.create_mask(label_batches[0].swapaxes(0, 1))
+        len_label_batches = len(label_batches[0].shape)
+        if(len_label_batches <= 1):
+            label_mask = self.create_mask(label_batches[0])
+        else:
+            label_mask = self.create_mask(label_batches[0].swapaxes(0, 1))
         label_batches = [self.zero_pad(batch) for batch in label_batches]
 
         if self.cond:

--- a/datasets/iamondb_utils.py
+++ b/datasets/iamondb_utils.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import cPickle
 import fnmatch
+import re
 
 from lxml import etree
 


### PR DESCRIPTION
This is downstream from #2 and #3.

It also includes a fix to `datasets/iamondb.py` that is necessary under numpy 10.2 because of [this change](https://github.com/numpy/numpy/commit/1d3bcb446771ff16e9cf06e3a5d9cac20e68c4ac#diff-2dbfdbb8037c3bbfb90d5cf7c7000ec8L653) to swapaxes.
